### PR TITLE
Fix numeric env variables

### DIFF
--- a/example-consumer/httpbin/values.yaml
+++ b/example-consumer/httpbin/values.yaml
@@ -25,12 +25,12 @@ platform-service:
     definedInBaseAndOverriddenValue: 
       valueFrom:
         secretKeyRef:
-          name: baseSecret
+          name: base-secret
           key: username
     onlyDefinedInBaseValue: 
       valueFrom:
         secretKeyRef:
-          name: baseSecret
+          name: base-secret
           key: username
 
   volumes:

--- a/helm/platform-service/templates/deployment.yaml
+++ b/helm/platform-service/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
 {{- if contains "valueFrom" ($value | toString) }}
 {{ $value | toYaml | trim | indent 14 }}
 {{- else }}
-              value: {{ $value }}
+              value: {{ $value | quote }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Fix is to quote variable values. Otherwise, parser tries to interpret it as a number instead of a string (which is what environment values are: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core).