### PR TITLE
Add support for istio proxy resource limit annotations

### DIFF
--- a/charts/platform-service/Chart.yaml
+++ b/charts/platform-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.1"
 description: Platform service chart
 name: platform-service
-version: 1.2.6
+version: 1.3.0

--- a/charts/platform-service/templates/deployment.yaml
+++ b/charts/platform-service/templates/deployment.yaml
@@ -64,7 +64,15 @@ spec:
         sidecar.istio.io/proxyMemory: {{ .Values.proxyResources.requests.memory }}
         {{- end }}
         {{- end }}
-        {{- with .Values.additionalPodAnnotations }}       
+        {{- if .Values.proxyResources.limits }}
+        {{- if .Values.proxyResources.limits.cpu }}
+        sidecar.istio.io/proxyCPULimit: {{ .Values.proxyResources.limits.cpu }}
+        {{- end }}
+        {{- if .Values.proxyResources.limits.memory }}
+        sidecar.istio.io/proxyMemoryLimit: {{ .Values.proxyResources.limits.memory }}
+        {{- end }}
+        {{- end }}
+        {{- with .Values.additionalPodAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:

--- a/charts/platform-service/values.yaml
+++ b/charts/platform-service/values.yaml
@@ -266,7 +266,8 @@ proxyResources:
   # requests:
   # cpu: 10m
   # memory: 64Mi
-  # limits are not currently supported
+  # limits:  
+
 
 nodeSelector: {}
 

--- a/testing/generate-results.sh
+++ b/testing/generate-results.sh
@@ -1,128 +1,108 @@
 # Run helm template to allow comparing differences from run to run
-# Replaces chart version with `test` to avoid creating diffs on every file for every change
 
 rm results/*.yaml
 echo `date` > results/run-date.txt
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
+./generate-test-chart.sh \
      > results/base-case.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set gateway.exposeService=false \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/not-exposed.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set sessionManagement.enabled=false \
     --show-only templates/deployment.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/no-sessman.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set sessionManagement.redirectToLogin=true \
     --show-only templates/deployment.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/sessman-with-redirect.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set mergeAppMetrics=true \
     --show-only templates/deployment.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/mergeAppMetrics.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set deploymentOnly=true \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/deployment-only.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set defaultRouting.enabled=false \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/vs-default-routing-disabled.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set defaultRouting.retries.enabled=true \
     --show-only templates/virtualservice.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/vs-with-retries.yaml
 
-
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set defaultRouting.allHosts=true \
     --show-only templates/virtualservice.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/vs-all-hosts.yaml
 
-
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set defaultRouting.urlPrefixes= \
     --show-only templates/virtualservice.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/vs-no-urlPrefixes.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set defaultRouting.rewriteUrlPrefix.enabled=false \
     --show-only templates/virtualservice.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/vs-rewriteUrlPrefix-disabled.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set defaultRouting.redirectOnNoTrailingSlash=false \
     --show-only templates/virtualservice.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/vs-no-slash-redirect.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     -f cors-policy-values.yaml \
     --show-only templates/virtualservice.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/vs-cors-policy.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set defaultRouting.urlExactMatches[0]="url1",defaultRouting.urlExactMatches[0]="url2" \
     --show-only templates/virtualservice.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/vs-exact-matches.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set defaultRouting.urlRegexes[0]="/api/.*" \
     --show-only templates/virtualservice.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/vs-regexPrefixes.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set opa.enabled=true \
     --show-only templates/deployment.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/opa-enabled.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     -f opa-resource-values.yaml \
     --set opa.enabled=true \
     --show-only templates/deployment.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/opa-with-resources.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set image.full=alt-registry/alt-repo:alt-tag \
     --show-only templates/deployment.yaml \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/full-image-syntax.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set image.fluxAutomation.enabled=true \
-    --debug \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/default-image-automation.yaml
 
-helm template test-release ../charts/platform-service -n test-ns -f values.yaml \
+./generate-test-chart.sh \
     --set image.fluxAutomation.enabled=true,image.fluxAutomation.filterTags.pattern='^dev-(?P<build>.*)',image.fluxAutomation.filterTags.extract='$build',image.fluxAutomation.policy.semver.range='> 0' \
     --show-only templates/image-policy.yaml \
     --show-only templates/image-repository.yaml \
-    --debug \
-    | sed 's/platform-service-.*/platform-service-test/g' \
     > results/image-automation-options.yaml
+
+./generate-test-chart.sh \
+    --set proxyResources.requests.cpu="1m",proxyResources.limits.cpu="2m",proxyResources.requests.memory="10Mi",proxyResources.limits.memory="20Mi" \
+    --show-only templates/deployment.yaml \
+    > results/proxy-resources.yaml
 
 echo " *** kubeval results ***"
 kubeval --ignore-missing-schemas results/*.yaml

--- a/testing/generate-test-chart.sh
+++ b/testing/generate-test-chart.sh
@@ -1,0 +1,5 @@
+# Wrapper for helm command to generate chart. 
+# Passes all parameters through to helm 
+# Removes the chart version to avoid creating diffs on every file for every change
+helm template test-release ../charts/platform-service -n test-ns -f values.yaml "$@" \
+    | sed 's/platform-service-.*/platform-service-test/g' \

--- a/testing/results/proxy-resources.yaml
+++ b/testing/results/proxy-resources.yaml
@@ -1,0 +1,105 @@
+---
+# Source: platform-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-release
+  labels:
+    app: test
+    app.kubernetes.io/name: test
+    helm.sh/chart: platform-service-test
+    app.kubernetes.io/instance: test-release
+    version: v1
+    state: stateful
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test
+      app.kubernetes.io/instance: test-release
+  template:
+    metadata:
+      labels:
+        app: test
+        app.kubernetes.io/name: test
+        helm.sh/chart: platform-service-test
+        app.kubernetes.io/instance: test-release
+        version: v1
+        state: stateful
+        session-management: backend
+        label1: "1"
+        label2: "2"
+      annotations:
+        sidecar.istio.io/proxyCPU: 1m
+        sidecar.istio.io/proxyMemory: 10Mi
+        sidecar.istio.io/proxyCPULimit: 2m
+        sidecar.istio.io/proxyMemoryLimit: 20Mi
+        anno1: "1"
+        anno2: "2"
+    spec:
+      serviceAccountName: test
+      securityContext:
+        {}
+      initContainers:
+        []
+      containers:
+
+        - name: test
+          image: "test.io/some/repository:latest"
+          imagePullPolicy: IfNotPresent
+
+          env:
+            - name: baseLevel
+              value: "only set at base"
+            - name: definedInBaseAndDuplicatedInOverride
+              value: "sharedValue"
+            - name: definedInBaseAndOverridden
+              value: "baseValue"
+            - name: definedInBaseAndOverriddenValue
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: base-secret
+            - name: onlyDefinedInBaseValue
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: base-secret
+          securityContext:
+            {}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 80
+            successThreshold: 3
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /health/startup
+              port: 80
+            periodSeconds: 10
+          volumeMounts:
+            - name: service-secrets
+              mountPath: /secrets
+
+          resources:
+            {}
+          terminationGracePeriodSeconds:
+            30
+      volumes:
+
+      - name: service-secrets
+        secret:
+          secretName: test-secrets

--- a/testing/results/run-date.txt
+++ b/testing/results/run-date.txt
@@ -1,1 +1,1 @@
-Tue Mar 5 15:54:31 PST 2024
+Thu Oct 3 10:53:14 PDT 2024


### PR DESCRIPTION
Add support for:
```yaml
proxyResources:
   limits:
      cpu:
      memory:
```
These will be written to the istio annotations: 
sidecar.istio.io/proxyCPULimit
sidecar.istio.io/proxyMemoryLimit

Also refactored some test code to remove boilerplate.