### PR TITLE
Move terminationGracePeriodSeconds to spec instead of container

### DIFF
--- a/charts/platform-service/Chart.yaml
+++ b/charts/platform-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.1"
 description: Platform service chart
 name: platform-service
-version: 1.4.1
+version: 1.4.2

--- a/charts/platform-service/templates/deployment.yaml
+++ b/charts/platform-service/templates/deployment.yaml
@@ -97,6 +97,7 @@ spec:
       {{- end }}
       {{- toYaml .Values.initContainersDefinitions | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
 {{- if .Values.opa.enabled }}
         - name: opa-istio
@@ -213,7 +214,6 @@ spec:
 
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-          terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#pod-v1-core

terminationGracePeriodSeconds is under spec, not spec.containers